### PR TITLE
Migrate to dataclasses and abc

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -1,5 +1,7 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 import datetime
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from batch_background_runs import BatchBackgroundRuns
 from batch_command_records import BatchCommandRecords
@@ -7,12 +9,12 @@ from command import Command
 from localuser import LocalUser
 
 
+@dataclass
 class NewBatch:
     """A list of commands to be performed."""
 
-    def __init__(self, commands: List[Command], title: Optional[str]) -> None:
-        self.commands = commands
-        self.title = title
+    commands: List[Command]
+    title: Optional[str]
 
     def cleanup(self) -> None:
         """Partially normalize the batch, as a convenience for users.
@@ -25,11 +27,6 @@ class NewBatch:
         if self.title is not None:
             self.title = self.title.strip()
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is NewBatch and \
-            self.commands == value.commands and \
-            self.title == value.title
-
     def __str__(self) -> str:
         command_strs = '\n'.join([str(command) for command in self.commands])
         if self.title:
@@ -37,87 +34,34 @@ class NewBatch:
         else:
             return command_strs
 
-    def __repr__(self) -> str:
-        return 'NewBatch(' + \
-            repr(self.commands) + ', ' + \
-            repr(self.title) + ')'
 
-
-class StoredBatch:
+@dataclass  # type: ignore
+class StoredBatch(ABC):
     """A list of commands to be performed for one user that has been registered."""
 
-    def __init__(self,
-                 id: int,
-                 local_user: LocalUser,
-                 domain: str,
-                 title: Optional[str],
-                 created: datetime.datetime,
-                 last_updated: datetime.datetime,
-                 command_records: BatchCommandRecords,
-                 background_runs: BatchBackgroundRuns):
-        self.id = id
-        self.local_user = local_user
-        self.domain = domain
-        self.title = title
-        self.created = created
-        self.last_updated = last_updated
-        self.command_records = command_records
-        self.background_runs = background_runs
+    id: int
+    local_user: LocalUser
+    domain: str
+    title: Optional[str]
+    created: datetime.datetime
+    last_updated: datetime.datetime
+    command_records: BatchCommandRecords
+    background_runs: BatchBackgroundRuns
+
+    @abstractmethod
+    def __str__(self) -> str:
+        pass
 
 
 class OpenBatch(StoredBatch):
     """A list of commands to be performed for one user that has been registered but not completed yet."""
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is OpenBatch and \
-            self.id == value.id and \
-            self.local_user == value.local_user and \
-            self.domain == value.domain and \
-            self.title == value.title and \
-            self.created == value.created and \
-            self.last_updated == value.last_updated and \
-            self.command_records == value.command_records and \
-            self.background_runs == value.background_runs
-
     def __str__(self) -> str:
         return 'batch #%d on %s by %s' % (self.id, self.domain, self.local_user.user_name)
-
-    def __repr__(self) -> str:
-        return 'OpenBatch(' + \
-            repr(self.id) + ', ' + \
-            repr(self.local_user) + ', ' + \
-            repr(self.domain) + ', ' + \
-            repr(self.title) + ', ' + \
-            repr(self.created) + ', ' + \
-            repr(self.last_updated) + ', ' + \
-            repr(self.command_records) + ', ' + \
-            repr(self.background_runs) + ')'
 
 
 class ClosedBatch(StoredBatch):
     """A list of commands that were performed for one user."""
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is ClosedBatch and \
-            self.id == value.id and \
-            self.local_user == value.local_user and \
-            self.domain == value.domain and \
-            self.title == value.title and \
-            self.created == value.created and \
-            self.last_updated == value.last_updated and \
-            self.command_records == value.command_records and \
-            self.background_runs == value.background_runs
-
     def __str__(self) -> str:
         return 'batch #%d on %s by %s' % (self.id, self.domain, self.local_user.user_name)
-
-    def __repr__(self) -> str:
-        return 'ClosedBatch(' + \
-            repr(self.id) + ', ' + \
-            repr(self.local_user) + ', ' + \
-            repr(self.domain) + ', ' + \
-            repr(self.title) + ', ' + \
-            repr(self.created) + ', ' + \
-            repr(self.last_updated) + ', ' + \
-            repr(self.command_records) + ', ' + \
-            repr(self.background_runs) + ')'

--- a/batch_background_runs.py
+++ b/batch_background_runs.py
@@ -1,18 +1,24 @@
+from abc import ABC, abstractmethod
 import datetime
 from typing import Optional, Sequence, Tuple
 
 from localuser import LocalUser
 
 
-class BatchBackgroundRuns:
+class BatchBackgroundRuns(ABC):
     """Accessor for the background runs of a StoredBatch."""
 
     def currently_running(self) -> bool:
         last = self.get_last()
         return last is not None and last[1] is None
 
+    @abstractmethod
     def get_last(self) -> Optional[Tuple[Tuple[datetime.datetime, LocalUser], Optional[Tuple[datetime.datetime, Optional[LocalUser]]]]]:
-        ...
+        """Get the last background run, if any.
 
+           A background run is a tuple of the time and user starting the background run,
+           and (if it’s finished) the time and (if it didn’t stop on its own) user stopping it."""
+
+    @abstractmethod
     def get_all(self) -> Sequence[Tuple[Tuple[datetime.datetime, LocalUser], Optional[Tuple[datetime.datetime, Optional[LocalUser]]]]]:
-        ...
+        """Get all the background runs."""

--- a/batch_command_records.py
+++ b/batch_command_records.py
@@ -1,32 +1,41 @@
+from abc import ABC, abstractmethod
 from typing import Dict, Iterator, List, Type
 
 from command import Command, CommandRecord, CommandPending, CommandFinish
 from page import Page
 
 
-class BatchCommandRecords:
+class BatchCommandRecords(ABC):
     """Accessor for the CommandRecords of a StoredBatch."""
 
+    @abstractmethod
     def get_slice(self, offset: int, limit: int) -> List[CommandRecord]:
-        ...
+        """Get up to limit command records from the given offset."""
 
+    @abstractmethod
     def get_summary(self) -> Dict[Type[CommandRecord], int]:
-        ...
+        """Get the number of command records for each concrete type."""
 
+    @abstractmethod
     def stream_pages(self) -> Iterator[Page]:
-        ...
+        """Get a stream of all the pages touched by a batch."""
 
+    @abstractmethod
     def stream_commands(self) -> Iterator[Command]:
-        ...
+        """Get a stream of all the commands in a batch."""
 
+    @abstractmethod
     def make_plans_pending(self, offset: int, limit: int) -> List[CommandPending]:
-        ...
+        """Mark up to limit command records from the given offset as pending and return them."""
 
+    @abstractmethod
     def make_pendings_planned(self, command_record_ids: List[int]) -> None:
-        ...
+        """Mark the pending command records with the given IDs as planned."""
 
+    @abstractmethod
     def store_finish(self, command_finish: CommandFinish) -> None:
-        ...
+        """Save the given finished command."""
 
+    @abstractmethod
     def __len__(self) -> int:
-        ...
+        """Get the number of command records in the batch."""

--- a/command.py
+++ b/command.py
@@ -8,7 +8,7 @@ from page import Page
 from siteinfo import CategoryInfo
 
 
-@dataclass
+@dataclass(frozen=True)
 class Command:
     """A list of actions to perform on a page."""
 
@@ -46,7 +46,7 @@ class Command:
         return str(self.page) + '|' + self.actions_tpsv()
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandRecord(ABC):
     """A command that was recorded in some store."""
 
@@ -80,7 +80,7 @@ class CommandSuccess(CommandFinish):
     """A command that was successfully run."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandEdit(CommandSuccess):
     """A command that resulted in an edit on a page."""
 
@@ -91,7 +91,7 @@ class CommandEdit(CommandSuccess):
         assert self.base_revision < self.revision
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandNoop(CommandSuccess):
     """A command that resulted in no change to a page."""
 
@@ -131,7 +131,7 @@ class CommandFailure(CommandFinish):
         (i. e., suspend background runs but resume them automatically)."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandPageMissing(CommandFailure):
     """A command that failed because the specified page was found to be missing at the time."""
 
@@ -147,7 +147,7 @@ class CommandPageMissing(CommandFailure):
         return True
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandTitleInvalid(CommandFailure):
     """A command that failed because the specified title was invalid."""
 
@@ -163,7 +163,7 @@ class CommandTitleInvalid(CommandFailure):
         return True
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandPageProtected(CommandFailure):
     """A command that failed because the specified page was protected at the time."""
 
@@ -192,7 +192,7 @@ class CommandEditConflict(CommandFailure):
         return True
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandMaxlagExceeded(CommandFailure):
     """A command that failed because replication lag in the database cluster was too high."""
 
@@ -208,7 +208,7 @@ class CommandMaxlagExceeded(CommandFailure):
         return self.retry_after
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandBlocked(CommandFailure):
     """A command that failed because the user or IP address was blocked."""
 
@@ -228,7 +228,7 @@ class CommandBlocked(CommandFailure):
         return False
 
 
-@dataclass
+@dataclass(frozen=True)
 class CommandWikiReadOnly(CommandFailure):
     """A command that failed because the wiki was in read-only mode."""
 

--- a/command.py
+++ b/command.py
@@ -1,17 +1,19 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 import datetime
-from typing import Any, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from action import Action
 from page import Page
 from siteinfo import CategoryInfo
 
 
+@dataclass
 class Command:
     """A list of actions to perform on a page."""
 
-    def __init__(self, page: Page, actions: List['Action']) -> None:
-        self.page = page
-        self.actions = actions
+    page: Page
+    actions: List['Action']
 
     def apply(self, wikitext: str, category_info: CategoryInfo) -> Tuple[str, List[Tuple[Action, bool]]]:
         """Apply the actions of this command to the given wikitext and return
@@ -40,54 +42,30 @@ class Command:
     def actions_tpsv(self) -> str:
         return '|'.join([str(action) for action in self.actions])
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is Command and \
-            self.page == value.page and \
-            self.actions == value.actions
-
     def __str__(self) -> str:
         return str(self.page) + '|' + self.actions_tpsv()
 
-    def __repr__(self) -> str:
-        return 'Command(' + repr(self.page) + ', ' + repr(self.actions) + ')'
 
-
-class CommandRecord:
+@dataclass
+class CommandRecord(ABC):
     """A command that was recorded in some store."""
 
-    def __init__(self, id: int, command: Command) -> None:
-        self.id = id
-        self.command = command
+    id: int
+    command: Command
 
 
 class CommandPlan(CommandRecord):
     """A command that should be run in the future."""
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandPlan and \
-            self.id == value.id and \
-            self.command == value.command
-
     def __str__(self) -> str:
         return str(self.command)
-
-    def __repr__(self) -> str:
-        return 'CommandPlan(' + repr(self.id) + ', ' + repr(self.command) + ')'
 
 
 class CommandPending(CommandRecord):
     """A command that is about to be run or currently running."""
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandPending and \
-            self.id == value.id and \
-            self.command == value.command
-
     def __str__(self) -> str:
         return str(self.command)
-
-    def __repr__(self) -> str:
-        return 'CommandPending(' + repr(self.id) + ', ' + repr(self.command) + ')'
 
 
 class CommandFinish(CommandRecord):
@@ -102,67 +80,42 @@ class CommandSuccess(CommandFinish):
     """A command that was successfully run."""
 
 
+@dataclass
 class CommandEdit(CommandSuccess):
     """A command that resulted in an edit on a page."""
 
-    def __init__(self, id: int, command: Command, base_revision: int, revision: int) -> None:
-        assert base_revision < revision
-        super().__init__(id, command)
-        self.base_revision = base_revision
-        self.revision = revision
+    base_revision: int
+    revision: int
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandEdit and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.base_revision == value.base_revision and \
-            self.revision == value.revision
-
-    def __repr__(self) -> str:
-        return 'CommandEdit(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            repr(self.base_revision) + ', ' + \
-            repr(self.revision) + ')'
+    def __post_init__(self) -> None:
+        assert self.base_revision < self.revision
 
 
+@dataclass
 class CommandNoop(CommandSuccess):
     """A command that resulted in no change to a page."""
 
-    def __init__(self, id: int, command: Command, revision: int) -> None:
-        super().__init__(id, command)
-        self.revision = revision
-
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandNoop and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.revision == value.revision
-
-    def __repr__(self) -> str:
-        return 'CommandNoop(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            repr(self.revision) + ')'
+    revision: int
 
 
 class CommandFailure(CommandFinish):
     """A command that was not successfully run."""
 
+    @abstractmethod
     def can_retry_immediately(self) -> bool:
         """Whether it is okay to retry running this command immediately.
 
         In case of an immediate retry, no permanent record of the failure is kept,
         so this should not be used if the failure resulted in any actions on the wiki."""
-        ...
 
+    @abstractmethod
     def can_retry_later(self) -> bool:
         """Whether it is okay to retry running this command at a later time.
 
         If True, a new command plan for the same command with a fresh ID
         will be appended to the end of the batch."""
-        ...
 
+    @abstractmethod
     def can_continue_batch(self) -> Union[bool, datetime.datetime]:
         """Whether it is okay to continue with other commands in this batch.
 
@@ -176,15 +129,13 @@ class CommandFailure(CommandFinish):
         (i. e., stop background runs and only proceed on manual input by the user);
         a datetime means that we should suspend the batch until that time
         (i. e., suspend background runs but resume them automatically)."""
-        ...
 
 
+@dataclass
 class CommandPageMissing(CommandFailure):
     """A command that failed because the specified page was found to be missing at the time."""
 
-    def __init__(self, id: int, command: Command, curtimestamp: str) -> None:
-        super().__init__(id, command)
-        self.curtimestamp = curtimestamp
+    curtimestamp: str
 
     def can_retry_immediately(self) -> bool:
         return False
@@ -195,25 +146,12 @@ class CommandPageMissing(CommandFailure):
     def can_continue_batch(self) -> bool:
         return True
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandPageMissing and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.curtimestamp == value.curtimestamp
 
-    def __repr__(self) -> str:
-        return 'CommandPageMissing(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            repr(self.curtimestamp) + ')'
-
-
+@dataclass
 class CommandTitleInvalid(CommandFailure):
     """A command that failed because the specified title was invalid."""
 
-    def __init__(self, id: int, command: Command, curtimestamp: str) -> None:
-        super().__init__(id, command)
-        self.curtimestamp = curtimestamp
+    curtimestamp: str
 
     def can_retry_immediately(self) -> bool:
         return False
@@ -224,25 +162,12 @@ class CommandTitleInvalid(CommandFailure):
     def can_continue_batch(self) -> bool:
         return True
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandTitleInvalid and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.curtimestamp == value.curtimestamp
 
-    def __repr__(self) -> str:
-        return 'CommandTitleInvalid(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            repr(self.curtimestamp) + ')'
-
-
+@dataclass
 class CommandPageProtected(CommandFailure):
     """A command that failed because the specified page was protected at the time."""
 
-    def __init__(self, id: int, command: Command, curtimestamp: str) -> None:
-        super().__init__(id, command)
-        self.curtimestamp = curtimestamp
+    curtimestamp: str
 
     def can_retry_immediately(self) -> bool:
         return False
@@ -252,18 +177,6 @@ class CommandPageProtected(CommandFailure):
 
     def can_continue_batch(self) -> bool:
         return True
-
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandPageProtected and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.curtimestamp == value.curtimestamp
-
-    def __repr__(self) -> str:
-        return 'CommandPageProtected(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            repr(self.curtimestamp) + ')'
 
 
 class CommandEditConflict(CommandFailure):
@@ -278,23 +191,12 @@ class CommandEditConflict(CommandFailure):
     def can_continue_batch(self) -> bool:
         return True
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandEditConflict and \
-            self.id == value.id and \
-            self.command == value.command
 
-    def __repr__(self) -> str:
-        return 'CommandEditConflict(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ')'
-
-
+@dataclass
 class CommandMaxlagExceeded(CommandFailure):
     """A command that failed because replication lag in the database cluster was too high."""
 
-    def __init__(self, id: int, command: Command, retry_after: datetime.datetime) -> None:
-        super().__init__(id, command)
-        self.retry_after = retry_after
+    retry_after: datetime.datetime
 
     def can_retry_immediately(self) -> bool:
         return False
@@ -305,26 +207,13 @@ class CommandMaxlagExceeded(CommandFailure):
     def can_continue_batch(self) -> datetime.datetime:
         return self.retry_after
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandMaxlagExceeded and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.retry_after == value.retry_after
 
-    def __repr__(self) -> str:
-        return 'CommandMaxlagExceeded(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            repr(self.retry_after) + ')'
-
-
+@dataclass
 class CommandBlocked(CommandFailure):
     """A command that failed because the user or IP address was blocked."""
 
-    def __init__(self, id: int, command: Command, auto: bool, blockinfo: Optional[dict]) -> None:
-        super().__init__(id, command)
-        self.auto = auto
-        self.blockinfo = blockinfo
+    auto: bool
+    blockinfo: Optional[dict]
 
     def can_retry_immediately(self) -> bool:
         return False
@@ -338,28 +227,13 @@ class CommandBlocked(CommandFailure):
         # but for now I’d rather not
         return False
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandBlocked and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.auto == value.auto and \
-            self.blockinfo == value.blockinfo
 
-    def __repr__(self) -> str:
-        return 'CommandBlocked(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            'auto=' + repr(self.auto) + ', ' + \
-            'blockinfo=' + repr(self.blockinfo) + ')'
-
-
+@dataclass
 class CommandWikiReadOnly(CommandFailure):
     """A command that failed because the wiki was in read-only mode."""
 
-    def __init__(self, id: int, command: Command, reason: Optional[str], retry_after: Optional[datetime.datetime]) -> None:
-        super().__init__(id, command)
-        self.reason = reason
-        self.retry_after = retry_after
+    reason: Optional[str]
+    retry_after: Optional[datetime.datetime]
 
     def can_retry_immediately(self) -> bool:
         return False
@@ -369,17 +243,3 @@ class CommandWikiReadOnly(CommandFailure):
 
     def can_continue_batch(self) -> Union[bool, datetime.datetime]:
         return self.retry_after or False
-
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is CommandWikiReadOnly and \
-            self.id == value.id and \
-            self.command == value.command and \
-            self.reason == value.reason and \
-            self.retry_after == value.retry_after
-
-    def __repr__(self) -> str:
-        return 'CommandWikiReadOnly(' + \
-            repr(self.id) + ', ' + \
-            repr(self.command) + ', ' + \
-            repr(self.reason) + ', ' + \
-            repr(self.retry_after) + ')'

--- a/database.py
+++ b/database.py
@@ -1,4 +1,5 @@
 import contextlib
+from dataclasses import dataclass
 import datetime
 import itertools
 import json
@@ -422,11 +423,11 @@ class DatabaseStore(BatchStore):
             return bool(val)
 
 
+@dataclass
 class _BatchCommandRecordsDatabase(BatchCommandRecords):
 
-    def __init__(self, batch_id: int, store: DatabaseStore) -> None:
-        self.batch_id = batch_id
-        self.store = store
+    batch_id: int
+    store: DatabaseStore
 
     def get_slice(self, offset: int, limit: int) -> List[CommandRecord]:
         command_records = []
@@ -595,12 +596,12 @@ class _BatchCommandRecordsDatabase(BatchCommandRecords):
             self.batch_id == value.batch_id
 
 
+@dataclass
 class _BatchBackgroundRunsDatabase(BatchBackgroundRuns):
 
-    def __init__(self, batch_id: int, domain: str, store: DatabaseStore) -> None:
-        self.batch_id = batch_id
-        self.domain = domain
-        self.store = store
+    batch_id: int
+    domain: str
+    store: DatabaseStore
 
     def currently_running(self) -> bool:
         with self.store.connect() as connection, connection.cursor() as cursor:
@@ -662,14 +663,14 @@ class _BatchBackgroundRunsDatabase(BatchBackgroundRuns):
             self.batch_id == value.batch_id
 
 
+@dataclass
 class _LocalUserStore:
     """Encapsulates access to a local user account in the localuser table.
 
        When a user has been renamed, the same ID will still be used
        and the name will be updated once the user is stored the next time."""
 
-    def __init__(self, domain_store: StringTableStore) -> None:
-        self.domain_store = domain_store
+    domain_store: StringTableStore
 
     def acquire_localuser_id(self, connection: pymysql.connections.Connection, local_user: LocalUser) -> int:
         domain_id = self.domain_store.acquire_id(connection, local_user.domain)

--- a/database.py
+++ b/database.py
@@ -423,7 +423,7 @@ class DatabaseStore(BatchStore):
             return bool(val)
 
 
-@dataclass
+@dataclass(frozen=True)
 class _BatchCommandRecordsDatabase(BatchCommandRecords):
 
     batch_id: int
@@ -596,7 +596,7 @@ class _BatchCommandRecordsDatabase(BatchCommandRecords):
             self.batch_id == value.batch_id
 
 
-@dataclass
+@dataclass(frozen=True)
 class _BatchBackgroundRunsDatabase(BatchBackgroundRuns):
 
     batch_id: int
@@ -663,7 +663,7 @@ class _BatchBackgroundRunsDatabase(BatchBackgroundRuns):
             self.batch_id == value.batch_id
 
 
-@dataclass
+@dataclass(frozen=True)
 class _LocalUserStore:
     """Encapsulates access to a local user account in the localuser table.
 

--- a/in_memory.py
+++ b/in_memory.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import datetime
 import mwapi  # type: ignore
 import mwoauth  # type: ignore
@@ -113,12 +114,12 @@ class InMemoryStore(BatchStore):
         return None
 
 
+@dataclass
 class _BatchCommandRecordsList(BatchCommandRecords):
 
-    def __init__(self, command_records: List[CommandRecord], batch_id: int, store: InMemoryStore) -> None:
-        self.command_records = command_records
-        self.batch_id = batch_id
-        self.store = store
+    command_records: List[CommandRecord]
+    batch_id: int
+    store: InMemoryStore
 
     def get_slice(self, offset: int, limit: int) -> List[CommandRecord]:
         return self.command_records[offset:offset+limit]
@@ -182,11 +183,11 @@ class _BatchCommandRecordsList(BatchCommandRecords):
             self.command_records == value.command_records
 
 
+@dataclass
 class _BatchBackgroundRunsList(BatchBackgroundRuns):
 
-    def __init__(self, background_runs: List[Tuple[Tuple[datetime.datetime, LocalUser], Optional[Tuple[datetime.datetime, Optional[LocalUser]]]]], store: InMemoryStore) -> None:
-        self.background_runs = background_runs
-        self.store = store
+    background_runs: List[Tuple[Tuple[datetime.datetime, LocalUser], Optional[Tuple[datetime.datetime, Optional[LocalUser]]]]]
+    store: InMemoryStore
 
     def get_last(self) -> Optional[Tuple[Tuple[datetime.datetime, LocalUser], Optional[Tuple[datetime.datetime, Optional[LocalUser]]]]]:
         if self.background_runs:

--- a/in_memory.py
+++ b/in_memory.py
@@ -114,7 +114,7 @@ class InMemoryStore(BatchStore):
         return None
 
 
-@dataclass
+@dataclass(frozen=True)
 class _BatchCommandRecordsList(BatchCommandRecords):
 
     command_records: List[CommandRecord]
@@ -183,7 +183,7 @@ class _BatchCommandRecordsList(BatchCommandRecords):
             self.command_records == value.command_records
 
 
-@dataclass
+@dataclass(frozen=True)
 class _BatchBackgroundRunsList(BatchBackgroundRuns):
 
     background_runs: List[Tuple[Tuple[datetime.datetime, LocalUser], Optional[Tuple[datetime.datetime, Optional[LocalUser]]]]]

--- a/localuser.py
+++ b/localuser.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 
-@dataclass
+@dataclass(frozen=True)
 class LocalUser:
     """A user account local to one wiki."""
 

--- a/localuser.py
+++ b/localuser.py
@@ -1,28 +1,14 @@
-from typing import Any
+from dataclasses import dataclass, field
 
 
+@dataclass
 class LocalUser:
     """A user account local to one wiki."""
 
-    def __init__(self, user_name: str, domain: str, local_user_id: int, global_user_id: int) -> None:
-        self.user_name = user_name
-        self.domain = domain
-        self.local_user_id = local_user_id
-        self.global_user_id = global_user_id
-
-    def __eq__(self, value: Any) -> bool:
-        # note: does not compare the user name, to account for renamed users
-        return type(value) is LocalUser and \
-            self.domain == value.domain and \
-            self.local_user_id == value.local_user_id and \
-            self.global_user_id == value.global_user_id
+    user_name: str = field(compare=False)  # ignored in __eq__, to account for renamed users
+    domain: str
+    local_user_id: int
+    global_user_id: int
 
     def __str__(self) -> str:
         return self.user_name + '@' + self.domain
-
-    def __repr__(self) -> str:
-        return 'LocalUser(' + \
-            repr(self.user_name) + ', ' + \
-            repr(self.domain) + ', ' + \
-            repr(self.local_user_id) + ', ' + \
-            repr(self.global_user_id) + ')'

--- a/page.py
+++ b/page.py
@@ -1,6 +1,8 @@
-from typing import Any, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 
+@dataclass
 class Page:
     """A specifier for a page on a wiki, optionally resolved."""
 
@@ -8,11 +10,9 @@ class Page:
     resolve_redirects: Optional[bool]
     resolution: Optional[dict] = None
 
-    def __init__(self, title: str, resolve_redirects: Optional[bool]) -> None:
-        if title.startswith('!'):
-            raise ValueError("page title '%s' cannot start with ! (ambiguous str)" % title)
-        self.title = title
-        self.resolve_redirects = resolve_redirects
+    def __post_init__(self) -> None:
+        if self.title.startswith('!'):
+            raise ValueError("page title '%s' cannot start with ! (ambiguous str)" % self.title)
 
     def cleanup(self) -> None:
         """Partially normalize the page, as a convenience for users.
@@ -22,16 +22,8 @@ class Page:
         """
         self.title = self.title.replace('_', ' ')
 
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is Page and \
-            self.title == value.title and \
-            self.resolve_redirects is value.resolve_redirects
-
     def __str__(self) -> str:
         if self.resolve_redirects is False:
             return '!' + self.title
         else:
             return self.title
-
-    def __repr__(self) -> str:
-        return 'Page(' + repr(self.title) + ', ' + repr(self.resolve_redirects) + ')'

--- a/runner.py
+++ b/runner.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import datetime
 import mwapi  # type: ignore
 from typing import Dict, List, Optional, cast
@@ -7,14 +8,16 @@ from page import Page
 import siteinfo
 
 
+@dataclass
 class Runner():
 
-    def __init__(self, session: mwapi.Session, summary_batch_title: Optional[str] = None, summary_batch_link: Optional[str] = None) -> None:
-        self.session = session
-        self.csrf_token = session.get(action='query',
-                                      meta='tokens')['query']['tokens']['csrftoken']
-        self.summary_batch_title = summary_batch_title
-        self.summary_batch_link = summary_batch_link
+    session: mwapi.Session
+    summary_batch_title: Optional[str] = None
+    summary_batch_link: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.csrf_token = self.session.get(action='query',
+                                           meta='tokens')['query']['tokens']['csrftoken']
 
     def resolve_pages(self, pages: List[Page]) -> None:
         pages_with_resolve_redirects: List[Page] = []

--- a/store.py
+++ b/store.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import datetime
 import mwapi  # type: ignore
 import mwoauth  # type: ignore
@@ -8,31 +9,40 @@ from command import CommandPending
 from localuser import LocalUser
 
 
-class BatchStore:
+class BatchStore(ABC):
 
+    @abstractmethod
     def store_batch(self, new_batch: NewBatch, session: mwapi.Session) -> OpenBatch:
-        ...
+        """Store the given batch and return it as a batch with ID."""
 
+    @abstractmethod
     def get_batch(self, id: int) -> Optional[StoredBatch]:
-        ...
+        """Get the batch with the given ID."""
 
+    @abstractmethod
     def get_batches_slice(self, offset: int, limit: int) -> Sequence[StoredBatch]:
-        ...
+        """Get up to limit batches from the given offset."""
 
+    @abstractmethod
     def get_batches_count(self) -> int:
-        ...
+        """Get the total number of stored batches."""
 
+    @abstractmethod
     def start_background(self, batch: OpenBatch, session: mwapi.Session) -> None:
-        ...
+        """Mark the given batch to be run in the background using the session’s credentials."""
 
+    @abstractmethod
     def stop_background(self, batch: StoredBatch, session: Optional[mwapi.Session] = None) -> None:
-        ...
+        """Mark the given batch to no longer be run in the background."""
 
+    @abstractmethod
     def suspend_background(self, batch: StoredBatch, until: datetime.datetime) -> None:
-        ...
+        """Mark the given batch to stop background runs until the given datetime."""
 
+    @abstractmethod
     def make_plan_pending_background(self, consumer_token: mwoauth.ConsumerToken, user_agent: str) -> Optional[Tuple[OpenBatch, CommandPending, mwapi.Session]]:
-        ...
+        """Pick one planned command from a batch that’s marked to be run in the background,
+           mark that command as pending and return it with credentials."""
 
 
 def _local_user_from_session(session: mwapi.Session) -> LocalUser:

--- a/stringstore.py
+++ b/stringstore.py
@@ -1,10 +1,12 @@
 import cachetools
+from dataclasses import dataclass
 import hashlib
 import operator
 import pymysql
 import threading
 
 
+@dataclass
 class StringTableStore:
     """Encapsulates access to a string that has been extracted into a separate table.
 
@@ -17,15 +19,12 @@ class StringTableStore:
     but to look up the string for an ID,
     callers should use a plain SQL JOIN for now."""
 
-    def __init__(self,
-                 table_name: str,
-                 id_column_name: str,
-                 hash_column_name: str,
-                 string_column_name: str):
-        self.table_name = table_name
-        self.id_column_name = id_column_name
-        self.hash_column_name = hash_column_name
-        self.string_column_name = string_column_name
+    table_name: str
+    id_column_name: str
+    hash_column_name: str
+    string_column_name: str
+
+    def __post_init__(self) -> None:
         self._cache: cachetools.LRUCache[str, int] = cachetools.LRUCache(maxsize=1024)
         self._cache_lock = threading.RLock()
 

--- a/test_action.py
+++ b/test_action.py
@@ -86,26 +86,8 @@ def test_AddCategoryAction_cleanup() -> None:
     action.cleanup()
     assert action == AddCategoryAction('User input from URL')
 
-def test_AddCategoryAction_eq_same() -> None:
-    assert addCategory1 == addCategory1
-
-def test_AddCategoryAction_eq_equal() -> None:
-    assert addCategory1 == AddCategoryAction(addCategory1.category)
-
-def test_AddCategoryAction_eq_different_type() -> None:
-    assert addCategory1 != RemoveCategoryAction(addCategory1.category)
-
-def test_AddCategoryAction_eq_different_category() -> None:
-    assert addCategory1 != addCategory2
-
-def test_AddCategoryAction_eq_different_category_normalization() -> None:
-    assert AddCategoryAction('Foo Bar') != AddCategoryAction('Foo_Bar')
-
 def test_AddCategoryAction_str() -> None:
     assert str(addCategory1) == '+Category:Cat 1'
-
-def test_AddCategoryAction_repr() -> None:
-    assert eval(repr(addCategory1)) == addCategory1
 
 
 @pytest.mark.parametrize('class_', [AddCategoryWithSortKeyAction, AddCategoryProvideSortKeyAction, AddCategoryReplaceSortKeyAction])
@@ -128,26 +110,8 @@ def test_AddCategoryWithSortKeyAction_apply(wikitext: str, expected: str) -> Non
     actual = action.apply(wikitext, ('Category', ['Category', 'Kategorie', 'K'], 'first-letter'))
     assert expected == actual
 
-def test_AddCategoryWithSortKeyAction_eq_same() -> None:
-    assert addCategoryWithSortKey1 == addCategoryWithSortKey1
-
-def test_AddCategoryWithSortKeyAction_eq_equal() -> None:
-    assert addCategoryWithSortKey1 == AddCategoryWithSortKeyAction(addCategoryWithSortKey1.category, addCategoryWithSortKey1.sort_key)
-
-def test_AddCategoryWithSortKeyAction_eq_different_type() -> None:
-    assert addCategoryWithSortKey1 != AddCategoryProvideSortKeyAction(addCategoryWithSortKey1.category, addCategoryWithSortKey1.sort_key)
-
-def test_AddCategoryWithSortKeyAction_eq_different_category() -> None:
-    assert addCategoryWithSortKey1 != AddCategoryWithSortKeyAction('Cat 2', addCategoryWithSortKey1.sort_key)
-
-def test_AddCategoryWithSortKeyAction_eq_different_sort_key() -> None:
-    assert addCategoryWithSortKey1 != AddCategoryWithSortKeyAction(addCategoryWithSortKey1.category, 'other sort key')
-
 def test_AddCategoryWithSortKeyAction_str() -> None:
     assert str(addCategoryWithSortKey1) == '+Category:Cat 1#sort key'
-
-def test_AddCategoryWithSortKeyAction_repr() -> None:
-    assert eval(repr(addCategoryWithSortKey1)) == addCategoryWithSortKey1
 
 
 @pytest.mark.parametrize('wikitext, expected', [
@@ -160,26 +124,8 @@ def test_AddCategoryProvideSortKeyAction_apply(wikitext: str, expected: str) -> 
     actual = action.apply(wikitext, ('Category', ['Category', 'Kategorie', 'K'], 'first-letter'))
     assert expected == actual
 
-def test_AddCategoryProvideSortKeyAction_eq_same() -> None:
-    assert addCategoryProvideSortKey1 == addCategoryProvideSortKey1
-
-def test_AddCategoryProvideSortKeyAction_eq_equal() -> None:
-    assert addCategoryProvideSortKey1 == AddCategoryProvideSortKeyAction(addCategoryProvideSortKey1.category, addCategoryProvideSortKey1.sort_key)
-
-def test_AddCategoryProvideSortKeyAction_eq_different_type() -> None:
-    assert addCategoryProvideSortKey1 != AddCategoryWithSortKeyAction(addCategoryProvideSortKey1.category, addCategoryProvideSortKey1.sort_key)
-
-def test_AddCategoryProvideSortKeyAction_eq_different_category() -> None:
-    assert addCategoryProvideSortKey1 != AddCategoryProvideSortKeyAction('Cat 2', addCategoryProvideSortKey1.sort_key)
-
-def test_AddCategoryProvideSortKeyAction_eq_different_sort_key() -> None:
-    assert addCategoryProvideSortKey1 != AddCategoryProvideSortKeyAction(addCategoryProvideSortKey1.category, 'other sort key')
-
 def test_AddCategoryProvideSortKeyAction_str() -> None:
     assert str(addCategoryProvideSortKey1) == '+Category:Cat 1##sort key'
-
-def test_AddCategoryProvideSortKeyAction_repr() -> None:
-    assert eval(repr(addCategoryProvideSortKey1)) == addCategoryProvideSortKey1
 
 
 @pytest.mark.parametrize('wikitext, expected', [
@@ -199,26 +145,8 @@ def test_AddCategoryReplaceSortKeyAction_apply_remove_sort_key() -> None:
     actual = action.apply(wikitext, ('Category', ['Category', 'Kategorie', 'K'], 'first-letter'))
     assert expected == actual
 
-def test_AddCategoryReplaceSortKeyAction_eq_same() -> None:
-    assert addCategoryReplaceSortKey1 == addCategoryReplaceSortKey1
-
-def test_AddCategoryReplaceSortKeyAction_eq_equal() -> None:
-    assert addCategoryReplaceSortKey1 == AddCategoryReplaceSortKeyAction(addCategoryReplaceSortKey1.category, addCategoryReplaceSortKey1.sort_key)
-
-def test_AddCategoryReplaceSortKeyAction_eq_different_type() -> None:
-    assert addCategoryReplaceSortKey1 != AddCategoryProvideSortKeyAction(addCategoryReplaceSortKey1.category, addCategoryReplaceSortKey1.sort_key)
-
-def test_AddCategoryReplaceSortKeyAction_eq_different_category() -> None:
-    assert addCategoryReplaceSortKey1 != AddCategoryReplaceSortKeyAction('Cat 2', addCategoryReplaceSortKey1.sort_key)
-
-def test_AddCategoryReplaceSortKeyAction_eq_different_sort_key() -> None:
-    assert addCategoryReplaceSortKey1 != AddCategoryReplaceSortKeyAction(addCategoryReplaceSortKey1.category, 'other sort key')
-
 def test_AddCategoryReplaceSortKeyAction_str() -> None:
     assert str(addCategoryReplaceSortKey1) == '+Category:Cat 1###sort key'
-
-def test_AddCategoryReplaceSortKeyAction_repr() -> None:
-    assert eval(repr(addCategoryReplaceSortKey1)) == addCategoryReplaceSortKey1
 
 
 @pytest.mark.parametrize('wikitext, expected', [
@@ -259,26 +187,8 @@ def test_RemoveCategoryAction_cleanup() -> None:
     action.cleanup()
     assert action == RemoveCategoryAction('User input from URL')
 
-def test_RemoveCategoryAction_eq_same() -> None:
-    assert removeCategory1 == removeCategory1
-
-def test_RemoveCategoryAction_eq_equal() -> None:
-    assert removeCategory1 == RemoveCategoryAction(removeCategory1.category)
-
-def test_RemoveCategoryAction_eq_different_type() -> None:
-    assert removeCategory1 != AddCategoryAction(removeCategory1.category)
-
-def test_RemoveCategoryAction_eq_different_category() -> None:
-    assert removeCategory1 != RemoveCategoryAction('Cat 2')
-
-def test_RemoveCategoryAction_eq_different_category_normalization() -> None:
-    assert RemoveCategoryAction('Foo Bar') != RemoveCategoryAction('Foo_Bar')
-
 def test_RemoveCategoryAction_str() -> None:
     assert str(removeCategory1) == '-Category:Cat 1'
-
-def test_RemoveCategoryAction_repr() -> None:
-    assert eval(repr(removeCategory1)) == removeCategory1
 
 
 def test_RemoveCategoryWithSortKeyAction_init_empty_sort_key() -> None:
@@ -298,23 +208,5 @@ def test_RemoveCategoryWithSortKeyAction_apply(wikitext: str, expected: str) -> 
     actual = action.apply(wikitext, ('Category', ['Category', 'Kategorie', 'K'], 'first-letter'))
     assert expected == actual
 
-def test_RemoveCategoryWithSortKeyAction_eq_same() -> None:
-    assert removeCategoryWithSortKey1 == removeCategoryWithSortKey1
-
-def test_RemoveCategoryWithSortKeyAction_eq_equal() -> None:
-    assert removeCategoryWithSortKey1 == RemoveCategoryWithSortKeyAction(removeCategoryWithSortKey1.category, removeCategoryWithSortKey1.sort_key)
-
-def test_RemoveCategoryWithSortKeyAction_eq_different_type() -> None:
-    assert removeCategoryWithSortKey1 != AddCategoryWithSortKeyAction(removeCategoryWithSortKey1.category, removeCategoryWithSortKey1.sort_key)
-
-def test_RemoveCategoryWithSortKeyAction_eq_different_category() -> None:
-    assert removeCategoryWithSortKey1 != RemoveCategoryWithSortKeyAction('Cat 2', removeCategoryWithSortKey1.sort_key)
-
-def test_RemoveCategoryWithSortKeyAction_eq_different_sort_key() -> None:
-    assert removeCategoryWithSortKey1 != RemoveCategoryWithSortKeyAction(removeCategoryWithSortKey1.category, 'other sort key')
-
 def test_RemoveCategoryWithSortKeyAction_str() -> None:
     assert str(removeCategoryWithSortKey1) == '-Category:Cat 1#sort key'
-
-def test_RemoveCategoryWithSortKeyAction_repr() -> None:
-    assert eval(repr(removeCategoryWithSortKey1)) == removeCategoryWithSortKey1

--- a/test_batch.py
+++ b/test_batch.py
@@ -10,7 +10,7 @@ from localuser import LocalUser  # NOQA “unused” import LocalUser needed for
 from page import Page
 
 from test_command import command1, command2, commandPlan1, commandEdit1
-from test_localuser import localUser1, localUser2
+from test_localuser import localUser2
 
 
 newBatch1 = NewBatch([command1, command2], 'Test batch 1')
@@ -25,30 +25,12 @@ def test_NewBatch_cleanup() -> None:
                               Command(Page('Page 2 from URL', True), [AddCategoryAction('Category from URL')])],
                              'test batch')
 
-def test_NewBatch_eq_same() -> None:
-    assert newBatch1 == newBatch1
-
-def test_NewBatch_eq_equal() -> None:
-    assert newBatch1 == NewBatch(newBatch1.commands, newBatch1.title)
-
-def test_NewBatch_eq_different_type() -> None:
-    assert newBatch1 != command1
-
-def test_NewBatch_eq_different_commands() -> None:
-    assert newBatch1 != NewBatch([command1], newBatch1.title)
-
-def test_NewBatch_eq_different_title() -> None:
-    assert newBatch1 != NewBatch(newBatch1.commands, 'Other batch')
-
 def test_NewBatch_str() -> None:
     assert str(newBatch1) == '''
 # Test batch 1
 Page 1|+Category:Cat 1|-Category:Cat 1
 !Page 2|+Category:Cat 2
 '''.strip()
-
-def test_NewBatch_repr() -> None:
-    assert eval(repr(newBatch1)) == newBatch1
 
 
 datetime1 = datetime.datetime(2019, 3, 17, 13, 23, 28, 251638, tzinfo=datetime.timezone.utc)
@@ -61,83 +43,9 @@ openBatch1 = OpenBatch(5, localUser2, 'commons.wikimedia.org', 'Test batch 1', d
 closedBatch1 = ClosedBatch(5, localUser2, 'commons.wikimedia.org', 'Test batch 1', datetime1, datetime2, batchCommandRecords1, batchBackgroundRuns1)
 
 
-def test_OpenBatch_eq_same() -> None:
-    assert openBatch1 == openBatch1
-
-def test_OpenBatch_eq_equal() -> None:
-    assert openBatch1 == OpenBatch(5, localUser2, 'commons.wikimedia.org', 'Test batch 1', datetime1, datetime2, batchCommandRecords1, batchBackgroundRuns1)
-
-def test_OpenBatch_eq_different_type() -> None:
-    assert openBatch1 != newBatch1
-    assert openBatch1 != closedBatch1
-
-def test_OpenBatch_eq_different_id() -> None:
-    assert openBatch1 != OpenBatch(6, openBatch1.local_user, openBatch1.domain, openBatch1.title, openBatch1.created, openBatch1.last_updated, openBatch1.command_records, openBatch1.background_runs)
-
-def test_OpenBatch_eq_different_user() -> None:
-    assert openBatch1 != OpenBatch(openBatch1.id, localUser1, openBatch1.domain, openBatch1.title, openBatch1.created, openBatch1.last_updated, openBatch1.command_records, openBatch1.background_runs)
-
-def test_OpenBatch_eq_different_domain() -> None:
-    assert openBatch1 != OpenBatch(openBatch1.id, openBatch1.local_user, 'meta.wikimedia.org', openBatch1.title, openBatch1.created, openBatch1.last_updated, openBatch1.command_records, openBatch1.background_runs)
-
-def test_OpenBatch_eq_different_title() -> None:
-    assert openBatch1 != OpenBatch(openBatch1.id, openBatch1.local_user, openBatch1.domain, 'Other batch', openBatch1.created, openBatch1.last_updated, openBatch1.command_records, openBatch1.background_runs)
-
-def test_OpenBatch_eq_different_created() -> None:
-    assert openBatch1 != OpenBatch(openBatch1.id, openBatch1.local_user, openBatch1.domain, openBatch1.title, datetime2, openBatch1.last_updated, openBatch1.command_records, openBatch1.background_runs)
-
-def test_OpenBatch_eq_different_last_updated() -> None:
-    assert openBatch1 != OpenBatch(openBatch1.id, openBatch1.local_user, openBatch1.domain, openBatch1.title, openBatch1.created, datetime1, openBatch1.command_records, openBatch1.background_runs)
-
-def test_OpenBatch_eq_different_command_records() -> None:
-    assert openBatch1 != OpenBatch(openBatch1.id, openBatch1.local_user, openBatch1.domain, openBatch1.title, openBatch1.created, openBatch1.last_updated, batchCommandRecords2, openBatch1.background_runs)
-
-def test_OpenBatch_eq_different_background_runs() -> None:
-    assert openBatch1 != OpenBatch(openBatch1.id, openBatch1.local_user, openBatch1.domain, openBatch1.title, openBatch1.created, openBatch1.last_updated, openBatch1.command_records, batchBackgroundRuns2)
-
 def test_OpenBatch_str() -> None:
     assert str(openBatch1) == '''batch #5 on commons.wikimedia.org by Lucas Werkmeister'''
 
-def test_OpenBatch_repr() -> None:
-    assert eval(repr(openBatch1)) == openBatch1
-
-
-def test_ClosedBatch_eq_same() -> None:
-    assert closedBatch1 == closedBatch1
-
-def test_ClosedBatch_eq_equal() -> None:
-    assert closedBatch1 == ClosedBatch(5, localUser2, 'commons.wikimedia.org', 'Test batch 1', datetime1, datetime2, batchCommandRecords1, batchBackgroundRuns1)
-
-def test_ClosedBatch_eq_different_type() -> None:
-    assert closedBatch1 != newBatch1
-    assert closedBatch1 != openBatch1
-
-def test_ClosedBatch_eq_different_id() -> None:
-    assert closedBatch1 != ClosedBatch(6, closedBatch1.local_user, closedBatch1.domain, closedBatch1.title, closedBatch1.created, closedBatch1.last_updated, closedBatch1.command_records, closedBatch1.background_runs)
-
-def test_ClosedBatch_eq_different_user() -> None:
-    assert closedBatch1 != ClosedBatch(closedBatch1.id, localUser1, closedBatch1.domain, closedBatch1.title, closedBatch1.created, closedBatch1.last_updated, closedBatch1.command_records, closedBatch1.background_runs)
-
-def test_ClosedBatch_eq_different_domain() -> None:
-    assert closedBatch1 != ClosedBatch(closedBatch1.id, closedBatch1.local_user, 'meta.wikimedia.org', closedBatch1.title, closedBatch1.created, closedBatch1.last_updated, closedBatch1.command_records, closedBatch1.background_runs)
-
-def test_ClosedBatch_eq_different_title() -> None:
-    assert closedBatch1 != ClosedBatch(closedBatch1.id, closedBatch1.local_user, closedBatch1.domain, 'Other batch', closedBatch1.created, closedBatch1.last_updated, closedBatch1.command_records, closedBatch1.background_runs)
-
-def test_ClosedBatch_eq_different_created() -> None:
-    assert closedBatch1 != ClosedBatch(closedBatch1.id, closedBatch1.local_user, closedBatch1.domain, closedBatch1.title, datetime2, closedBatch1.last_updated, closedBatch1.command_records, closedBatch1.background_runs)
-
-def test_ClosedBatch_eq_different_last_updated() -> None:
-    assert closedBatch1 != ClosedBatch(closedBatch1.id, closedBatch1.local_user, closedBatch1.domain, closedBatch1.title, closedBatch1.created, datetime1, closedBatch1.command_records, closedBatch1.background_runs)
-
-def test_ClosedBatch_eq_different_command_records() -> None:
-    assert closedBatch1 != ClosedBatch(closedBatch1.id, closedBatch1.local_user, closedBatch1.domain, closedBatch1.title, closedBatch1.created, closedBatch1.last_updated, batchCommandRecords2, closedBatch1.background_runs)
-
-def test_ClosedBatch_eq_different_background_runs() -> None:
-    assert closedBatch1 != ClosedBatch(closedBatch1.id, closedBatch1.local_user, closedBatch1.domain, closedBatch1.title, closedBatch1.created, closedBatch1.last_updated, closedBatch1.command_records, batchBackgroundRuns2)
 
 def test_ClosedBatch_str() -> None:
     assert str(closedBatch1) == '''batch #5 on commons.wikimedia.org by Lucas Werkmeister'''
-
-def test_ClosedBatch_repr() -> None:
-    assert eval(repr(closedBatch1)) == closedBatch1

--- a/test_command.py
+++ b/test_command.py
@@ -34,78 +34,22 @@ def test_Command_cleanup() -> None:
 def test_Command_actions_tpsv() -> None:
     assert command1.actions_tpsv() == '+Category:Cat 1|-Category:Cat 1'
 
-def test_Command_eq_same() -> None:
-    assert command1 == command1
-
-def test_Command_eq_equal() -> None:
-    assert command1 == Command(command1.page, command1.actions)
-
-def test_Command_eq_different_type() -> None:
-    assert command1 != addCategory1
-
-def test_Command_eq_different_page() -> None:
-    assert command1 != Command(Page('Page A', True), command1.actions)
-    assert command1 != Command(Page('Page_1', True), command1.actions)
-    assert command1 != Command(Page('Page 1', False), command1.actions)
-
-def test_Command_eq_different_actions() -> None:
-    assert command1 != Command(command1.page, [addCategory1])
-
 def test_Command_str() -> None:
     assert str(command1) == 'Page 1|+Category:Cat 1|-Category:Cat 1'
-
-def test_Command_repr() -> None:
-    assert eval(repr(command1)) == command1
 
 
 commandPlan1 = CommandPlan(42, command1)
 
 
-def test_CommandPlan_eq_same() -> None:
-    assert commandPlan1 == commandPlan1
-
-def test_CommandPlan_eq_equal() -> None:
-    assert commandPlan1 == CommandPlan(commandPlan1.id, commandPlan1.command)
-
-def test_CommandPlan_eq_different_type() -> None:
-    assert commandPlan1 != commandPending1
-
-def test_CommandPlan_eq_different_id() -> None:
-    assert commandPlan1 != CommandPlan(43, commandPlan1.command)
-
-def test_CommandPlan_eq_different_command() -> None:
-    assert commandPlan1 != CommandPlan(commandPlan1.id, command2)
-
 def test_CommandPlan_str() -> None:
     assert str(commandPlan1) == str(command1)
-
-def test_CommandPlan_repr() -> None:
-    assert eval(repr(commandPlan1)) == commandPlan1
 
 
 commandPending1 = CommandPending(42, command1)
 
 
-def test_CommandPending_eq_same() -> None:
-    assert commandPending1 == commandPending1
-
-def test_CommandPending_eq_equal() -> None:
-    assert commandPending1 == CommandPending(commandPending1.id, commandPending1.command)
-
-def test_CommandPending_eq_different_type() -> None:
-    assert commandPending1 != commandPlan1
-
-def test_CommandPending_eq_different_id() -> None:
-    assert commandPending1 != CommandPending(43, commandPending1.command)
-
-def test_CommandPending_eq_different_command() -> None:
-    assert commandPending1 != CommandPending(commandPending1.id, command2)
-
 def test_CommandPending_str() -> None:
     assert str(commandPending1) == str(command1)
-
-def test_CommandPending_repr() -> None:
-    assert eval(repr(commandPending1)) == commandPending1
 
 
 commandEdit1 = CommandEdit(42, command2, 1234, 1235)
@@ -115,54 +59,15 @@ def test_CommandEdit_init() -> None:
     with pytest.raises(AssertionError):
         CommandEdit(42, command1, base_revision=1235, revision=1234)
 
-def test_CommandEdit_eq_same() -> None:
-    assert commandEdit1 == commandEdit1
-
-def test_CommandEdit_eq_equal() -> None:
-    assert commandEdit1 == CommandEdit(42, command2, 1234, 1235)
-
-def test_CommandEdit_eq_different_id() -> None:
-    assert commandEdit1 != CommandEdit(43, commandEdit1.command, commandEdit1.base_revision, commandEdit1.revision)
-
-def test_CommandEdit_eq_different_command() -> None:
-    assert commandEdit1 != CommandEdit(commandEdit1.id, command1, commandEdit1.base_revision, commandEdit1.revision)
-
-def test_CommandEdit_eq_different_base_revisoin() -> None:
-    assert commandEdit1 != CommandEdit(commandEdit1.id, commandEdit1.command, 1233, commandEdit1.revision)
-
-def test_CommandEdit_eq_different_revision() -> None:
-    assert commandEdit1 != CommandEdit(commandEdit1.id, commandEdit1.command, commandEdit1.base_revision, 1236)
-
 def test_CommandEdit_str() -> None:
     assert str(commandEdit1) == '# ' + str(command2)
-
-def test_CommandEdit_repr() -> None:
-    assert eval(repr(commandEdit1)) == commandEdit1
 
 
 commandNoop1 = CommandNoop(42, command2, 1234)
 
 
-def test_CommandNoop_eq_same() -> None:
-    assert commandNoop1 == commandNoop1
-
-def test_CommandNoop_eq_equal() -> None:
-    assert commandNoop1 == CommandNoop(42, command2, 1234)
-
-def test_CommandNoop_eq_different_id() -> None:
-    assert commandNoop1 != CommandNoop(43, commandNoop1.command, commandNoop1.revision)
-
-def test_CommandNoop_eq_different_command() -> None:
-    assert commandNoop1 != CommandNoop(commandNoop1.id, command1, commandNoop1.revision)
-
-def test_CommandNoop_eq_different_revision() -> None:
-    assert commandNoop1 != CommandNoop(commandNoop1.id, commandNoop1.command, 1235)
-
 def test_CommandNoop_str() -> None:
     assert str(commandNoop1) == '# ' + str(command2)
-
-def test_CommandNoop_repr() -> None:
-    assert eval(repr(commandNoop1)) == commandNoop1
 
 
 commandWithMissingPage = Command(Page('Page that definitely does not exist', True), command2.actions)
@@ -178,30 +83,8 @@ def test_CommandPageMissing_can_retry_later() -> None:
 def test_CommandPageMissing_can_continue_batch() -> None:
     assert commandPageMissing1.can_continue_batch()
 
-def test_CommandPageMissing_eq_same() -> None:
-    assert commandPageMissing1 == commandPageMissing1
-
-def test_CommandPageMissing_eq_equal() -> None:
-    assert commandPageMissing1 == CommandPageMissing(42, commandWithMissingPage, '2019-03-11T23:26:02Z')
-
-def test_CommandPageMissing_eq_different_type() -> None:
-    assert commandPageMissing1 != commandPageProtected1
-    assert commandPageMissing1 != commandTitleInvalid1
-
-def test_CommandPageMissing_eq_different_id() -> None:
-    assert commandPageMissing1 != CommandPageMissing(43, commandPageMissing1.command, commandPageMissing1.curtimestamp)
-
-def test_CommandPageMissing_eq_different_command() -> None:
-    assert commandPageMissing1 != CommandPageMissing(commandPageMissing1.id, command2, commandPageMissing1.curtimestamp)
-
-def test_CommandPageMissing_eq_different_curtimestamp() -> None:
-    assert commandPageMissing1 != CommandPageMissing(commandPageMissing1.id, commandPageMissing1.command, '2019-03-11T23:28:12Z')
-
 def test_CommandPageMissing_str() -> None:
     assert str(commandPageMissing1) == '# ' + str(commandWithMissingPage)
-
-def test_CommandPageMissing_repr() -> None:
-    assert eval(repr(commandPageMissing1)) == commandPageMissing1
 
 
 commandWithInvalidTitle = Command(Page('Category:', True), command2.actions)
@@ -217,30 +100,8 @@ def test_CommandTitleInvalid_can_retry_later() -> None:
 def test_CommandTitleInvalid_can_continue_batch() -> None:
     assert commandTitleInvalid1.can_continue_batch()
 
-def test_CommandTitleInvalid_eq_same() -> None:
-    assert commandTitleInvalid1 == commandTitleInvalid1
-
-def test_CommandTitleInvalid_eq_equal() -> None:
-    assert commandTitleInvalid1 == CommandTitleInvalid(42, commandWithInvalidTitle, '2019-03-11T23:26:02Z')
-
-def test_CommandTitleInvalid_eq_different_type() -> None:
-    assert commandTitleInvalid1 != commandPageProtected1
-    assert commandTitleInvalid1 != commandPageMissing1
-
-def test_CommandTitleInvalid_eq_different_id() -> None:
-    assert commandTitleInvalid1 != CommandTitleInvalid(43, commandTitleInvalid1.command, commandTitleInvalid1.curtimestamp)
-
-def test_CommandTitleInvalid_eq_different_command() -> None:
-    assert commandTitleInvalid1 != CommandTitleInvalid(commandTitleInvalid1.id, command2, commandTitleInvalid1.curtimestamp)
-
-def test_CommandTitleInvalid_eq_different_curtimestamp() -> None:
-    assert commandTitleInvalid1 != CommandTitleInvalid(commandTitleInvalid1.id, commandTitleInvalid1.command, '2019-03-11T23:28:12Z')
-
 def test_CommandTitleInvalid_str() -> None:
     assert str(commandTitleInvalid1) == '# ' + str(commandWithInvalidTitle)
-
-def test_CommandTitleInvalid_repr() -> None:
-    assert eval(repr(commandTitleInvalid1)) == commandTitleInvalid1
 
 
 commandWithProtectedPage = Command(Page('Main Page', True), command2.actions)
@@ -256,29 +117,8 @@ def test_CommandPageProtected_can_retry_later() -> None:
 def test_CommandPageProtected_can_continue_batch() -> None:
     assert commandPageProtected1.can_continue_batch()
 
-def test_CommandPageProtected_eq_same() -> None:
-    assert commandPageProtected1 == commandPageProtected1
-
-def test_CommandPageProtected_eq_equal() -> None:
-    assert commandPageProtected1 == CommandPageProtected(42, commandWithProtectedPage, '2019-03-11T23:26:02Z')
-
-def test_CommandPageProtected_eq_different_type() -> None:
-    assert commandPageProtected1 != commandPageMissing1
-
-def test_CommandPageProtected_eq_different_id() -> None:
-    assert commandPageProtected1 != CommandPageProtected(43, commandPageProtected1.command, commandPageProtected1.curtimestamp)
-
-def test_CommandPageProtected_eq_different_command() -> None:
-    assert commandPageProtected1 != CommandPageProtected(commandPageProtected1.id, command2, commandPageProtected1.curtimestamp)
-
-def test_CommandPageProtected_eq_different_curtimestamp() -> None:
-    assert commandPageProtected1 != CommandPageProtected(commandPageProtected1.id, commandPageProtected1.command, '2019-03-11T23:28:12Z')
-
 def test_CommandPageProtected_str() -> None:
     assert str(commandPageProtected1) == '# ' + str(commandWithProtectedPage)
-
-def test_CommandPageProtected_repr() -> None:
-    assert eval(repr(commandPageProtected1)) == commandPageProtected1
 
 
 commandEditConflict1 = CommandEditConflict(42, command1)
@@ -293,23 +133,8 @@ def test_CommandEditConflict_can_retry_later() -> None:
 def test_CommandEditConflict_can_continue_batch() -> None:
     assert commandEditConflict1.can_continue_batch()
 
-def test_CommandEditConflict_eq_same() -> None:
-    assert commandEditConflict1 == commandEditConflict1
-
-def test_CommandEditConflict_eq_equal() -> None:
-    assert commandEditConflict1 == CommandEditConflict(42, command1)
-
-def test_CommandEditConflict_eq_different_id() -> None:
-    assert commandEditConflict1 != CommandEditConflict(43, commandEditConflict1.command)
-
-def test_CommandEditConflict_eq_different_command() -> None:
-    assert commandEditConflict1 != CommandEditConflict(commandEditConflict1.id, command2)
-
 def test_CommandEditConflict_str() -> None:
     assert str(commandEditConflict1) == '# ' + str(command1)
-
-def test_CommandEditConflict_repr() -> None:
-    assert eval(repr(commandEditConflict1)) == commandEditConflict1
 
 
 commandMaxlagExceeded1 = CommandMaxlagExceeded(42, command1, datetime.datetime(2019, 3, 16, 15, 24, 2, tzinfo=datetime.timezone.utc))
@@ -324,26 +149,8 @@ def test_CommandMaxlagExceeded_can_retry_later() -> None:
 def test_CommandMaxlagExceeded_can_continue_batch() -> None:
     assert commandMaxlagExceeded1.can_continue_batch() == commandMaxlagExceeded1.retry_after
 
-def test_CommandMaxlagExceeded_eq_same() -> None:
-    assert commandMaxlagExceeded1 == commandMaxlagExceeded1
-
-def test_CommandMaxlagExceeded_eq_equal() -> None:
-    assert commandMaxlagExceeded1 == CommandMaxlagExceeded(42, command1, datetime.datetime(2019, 3, 16, 15, 24, 2, tzinfo=datetime.timezone.utc))
-
-def test_CommandMaxlagExceeded_eq_different_id() -> None:
-    assert commandMaxlagExceeded1 != CommandMaxlagExceeded(43, commandMaxlagExceeded1.command, commandMaxlagExceeded1.retry_after)
-
-def test_CommandMaxlagExceeded_eq_different_command() -> None:
-    assert commandMaxlagExceeded1 != CommandMaxlagExceeded(commandMaxlagExceeded1.id, command2, commandMaxlagExceeded1.retry_after)
-
-def test_CommandMaxlagExceeded_eq_different_retry_after() -> None:
-    assert commandMaxlagExceeded1 != CommandMaxlagExceeded(commandMaxlagExceeded1.id, commandMaxlagExceeded1.command, datetime.datetime(2019, 3, 16, 15, 24, 2, tzinfo=datetime.timezone.max))
-
 def test_CommandMaxlagExceeded_str() -> None:
     assert str(commandMaxlagExceeded1) == '# ' + str(command1)
-
-def test_CommandMaxlagExceeded_repr() -> None:
-    assert eval(repr(commandMaxlagExceeded1)) == commandMaxlagExceeded1
 
 
 blockinfo = {
@@ -368,29 +175,8 @@ def test_CommandBlocked_can_retry_later() -> None:
 def test_CommandBlocked_can_continue_batch() -> None:
     assert not commandBlocked1.can_continue_batch()
 
-def test_CommandBlocked_eq_same() -> None:
-    assert commandBlocked1 == commandBlocked1
-
-def test_CommandBlocked_eq_equal() -> None:
-    assert commandBlocked1 == CommandBlocked(42, command1, False, blockinfo)
-
-def test_CommandBlocked_eq_different_id() -> None:
-    assert commandBlocked1 != CommandBlocked(43, commandBlocked1.command, commandBlocked1.auto, commandBlocked1.blockinfo)
-
-def test_CommandBlocked_eq_different_command() -> None:
-    assert commandBlocked1 != CommandBlocked(commandBlocked1.id, command2, commandBlocked1.auto, commandBlocked1.blockinfo)
-
-def test_CommandBlocked_eq_different_auto() -> None:
-    assert commandBlocked1 != CommandBlocked(commandBlocked1.id, commandBlocked1.command, True, blockinfo)
-
-def test_CommandBlocked_eq_different_blockinfo() -> None:
-    assert commandBlocked1 != CommandBlocked(commandBlocked1.id, commandBlocked1.command, commandBlocked1.auto, None)
-
 def test_CommandBlocked_str() -> None:
     assert str(commandBlocked1) == '# ' + str(command1)
-
-def test_CommandBlocked_repr() -> None:
-    assert eval(repr(commandBlocked1)) == commandBlocked1
 
 
 commandWikiReadOnly1 = CommandWikiReadOnly(42, command1, 'maintenance', datetime.datetime(2019, 3, 16, 15, 24, 2, tzinfo=datetime.timezone.utc))
@@ -407,26 +193,5 @@ def test_CommandWikiReadOnly_can_continue_batch() -> None:
     assert commandWikiReadOnly1.can_continue_batch() == commandWikiReadOnly1.retry_after
     assert commandWikiReadOnly2.can_continue_batch() is False
 
-def test_CommandWikiReadOnly_eq_same() -> None:
-    assert commandWikiReadOnly1 == commandWikiReadOnly1
-
-def test_CommandWikiReadOnly_eq_equal() -> None:
-    assert commandWikiReadOnly1 == CommandWikiReadOnly(42, command1, 'maintenance', datetime.datetime(2019, 3, 16, 15, 24, 2, tzinfo=datetime.timezone.utc))
-
-def test_CommandWikiReadOnly_eq_different_id() -> None:
-    assert commandWikiReadOnly1 != CommandWikiReadOnly(43, commandWikiReadOnly1.command, commandWikiReadOnly1.reason, commandWikiReadOnly1.retry_after)
-
-def test_CommandWikiReadOnly_eq_different_command() -> None:
-    assert commandWikiReadOnly1 != CommandWikiReadOnly(commandWikiReadOnly1.id, command2, commandWikiReadOnly1.reason, commandWikiReadOnly1.retry_after)
-
-def test_CommandWikiReadOnly_eq_different_reason() -> None:
-    assert commandWikiReadOnly1 != CommandWikiReadOnly(commandWikiReadOnly1.id, commandWikiReadOnly1.command, None, commandWikiReadOnly1.retry_after)
-
-def test_CommandWikiReadOnly_eq_different_retry_after() -> None:
-    assert commandWikiReadOnly1 != CommandWikiReadOnly(commandWikiReadOnly1.id, commandWikiReadOnly1.command, commandWikiReadOnly1.reason, None)
-
 def test_CommandWikiReadOnly_str() -> None:
     assert str(commandWikiReadOnly1) == '# ' + str(command1)
-
-def test_CommandWikiReadOnly_repr() -> None:
-    assert eval(repr(commandWikiReadOnly1)) == commandWikiReadOnly1

--- a/test_localuser.py
+++ b/test_localuser.py
@@ -5,31 +5,5 @@ localUser1 = LocalUser('Lucas Werkmeister', 'www.wikidata.org', 2794369, 4605476
 localUser2 = LocalUser('Lucas Werkmeister', 'commons.wikimedia.org', 6198807, 46054761)
 
 
-def test_LocalUser_eq_same() -> None:
-    assert localUser1 == localUser1
-
-def test_LocalUser_eq_equal() -> None:
-    assert localUser1 == LocalUser('Lucas Werkmeister', 'www.wikidata.org', 2794369, 46054761)
-
-def test_LocalUser_eq_different_type() -> None:
-    assert localUser1 != 'Lucas Werkmeister'
-    assert localUser1 != 2794369
-
-def test_LocalUser_eq_different_user_name() -> None:
-    # still considered equal
-    assert localUser1 == LocalUser('Lucas Werkmeister (renamed)', 'www.wikidata.org', 2794369, 46054761)
-
-def test_LocalUser_eq_different_domain() -> None:
-    assert localUser1 != LocalUser('Lucas Werkmeister', 'commons.wikimedia.org', 2794369, 46054761)
-
-def test_LocalUser_eq_different_local_user_id() -> None:
-    assert localUser1 != LocalUser('Lucas Werkmeister', 'www.wikidata.org', 27943690, 46054761)
-
-def test_LocalUser_eq_different_global_user_id() -> None:
-    assert localUser1 != LocalUser('Lucas Werkmeister', 'www.wikidata.org', 2794369, 460547610)
-
 def test_LocalUser_str() -> None:
     assert str(localUser1) == 'Lucas Werkmeister@www.wikidata.org'
-
-def test_LocalUser_repr() -> None:
-    assert eval(repr(localUser1)) == localUser1

--- a/test_page.py
+++ b/test_page.py
@@ -27,7 +27,6 @@ def test_Page_eq_different_title() -> None:
 def test_Page_eq_different_resolve_redirects() -> None:
     assert page1 != Page(page1.title, False)
     assert page1 != Page(page1.title, None)
-    assert page1 != Page(page1.title, 1)  # type: ignore
 
 def test_Page_str() -> None:
     assert str(page1) == 'Page 1'

--- a/test_page.py
+++ b/test_page.py
@@ -1,4 +1,3 @@
-from action import AddCategoryAction
 from page import Page
 
 
@@ -11,27 +10,6 @@ def test_Page_cleanup() -> None:
     page.cleanup()
     assert page == Page('Page from URL', True)
 
-def test_Page_eq_same() -> None:
-    assert page1 == page1
-
-def test_Page_eq_equal() -> None:
-    assert page1 == Page(page1.title, page1.resolve_redirects)
-
-def test_Page_eq_different_type() -> None:
-    assert page1 != AddCategoryAction('Page 1')
-
-def test_Page_eq_different_title() -> None:
-    assert page1 != Page('Page A', page1.resolve_redirects)
-    assert page1 != Page('Page_1', page1.resolve_redirects)
-
-def test_Page_eq_different_resolve_redirects() -> None:
-    assert page1 != Page(page1.title, False)
-    assert page1 != Page(page1.title, None)
-
 def test_Page_str() -> None:
     assert str(page1) == 'Page 1'
     assert str(page2) == '!Page 2'
-
-def test_Page_repr() -> None:
-    assert eval(repr(page1)) == page1
-    assert eval(repr(page2)) == page2


### PR DESCRIPTION
The potential of using the [dataclasses module][1] to simplify some implementations was already mentioned way back in commit 30b0f2abbf, but at the time we couldn’t use it, because Python 3.7 was not available in Toolforge yet. That’s no longer an issue, so we can now remove a lot of hand-written constructors and eq and repr implementations.

The tests for eq and repr are also removed, because I see no need to test the autogenerated methods. Note that the test removals were committed after the dataclasses migration, and CI still passed when running the old test against the new implementation.

At the same time we also migrate to the [abc module][2] to properly mark abstract classes.

[1]: https://docs.python.org/3/library/dataclasses.html
[2]: https://docs.python.org/3/library/abc.html