### PR TITLE
 Add support for actions and title URL parameters in PagePile batch

### DIFF
--- a/app.py
+++ b/app.py
@@ -377,6 +377,8 @@ def new_batch_from_pagepile() -> RRV:
     if flask.request.method == 'GET':
         return flask.render_template('new_batch_from_pagepile.html',
                                      page_pile_id=flask.request.args.get('page_pile_id'),
+                                     actions=flask.request.args.get('actions'),
+                                     title=flask.request.args.get('title'),
                                      read_only_reason=app.config.get('READ_ONLY_REASON'))
 
     if read_only_reason := app.config.get('READ_ONLY_REASON'):

--- a/templates/new_batch_from_pagepile.html
+++ b/templates/new_batch_from_pagepile.html
@@ -27,7 +27,9 @@
       id="actions" class="form-control"
       name="actions" type="text"
       required
-      {% if page_pile_id %}
+      {% if actions %}
+      value="{{ actions }}"
+      {% elif page_pile_id %}
       autofocus
       {% endif %}
       placeholder="+Category:Test|-Category:Other test|+Category:Sandbox##sort key">
@@ -39,6 +41,9 @@
       name="title" type="text"
       aria-describedby="titleHelp"
       maxlength="800"
+      {% if title %}
+      value="{{ title }}"
+      {% endif %}
       placeholder="based on Wikidata [[d:P:P1532|country for sport]]">
     <small id="titleHelp" class="form-text text-muted">
       Optional.


### PR DESCRIPTION
This pull request allows passing the actions and title parameters via URL or form submission to the QuickCategories batch creation page, in addition to the existing page_pile_id parameter.

**What was done:**
- Updated app.py route /batch/new/pagepile to accept and handle actions and title parameters from GET requests.
- Modified the batch creation form template to include fields for actions and title prefilled from URL parameters.
- Verified that the page pile ID, actions, and title work correctly when submitted via URL parameters.

**Phabricator Task** - [T397320](https://phabricator.wikimedia.org/T397320)